### PR TITLE
Update IPset name to ipfilter-net0

### DIFF
--- a/app/Services/Servers/NetworkService.php
+++ b/app/Services/Servers/NetworkService.php
@@ -45,7 +45,7 @@ class NetworkService
         }
     }
 
-    public function lockIps(Server $server, array $addresses, string $ipsetName = 'default')
+    public function lockIps(Server $server, array $addresses, string $ipsetName = 'ipfilter-net0')
     {
         $this->firewallRepository->setServer($server);
 


### PR DESCRIPTION
It may be required for ipset to apply on the net0 interface, so setting it to ipfilter-net0 is ideal