### PR TITLE
Update NIC Code

### DIFF
--- a/app/Services/Servers/NetworkService.php
+++ b/app/Services/Servers/NetworkService.php
@@ -141,7 +141,11 @@ class NetworkService
             $payload .= ',rate=' . $mebibytes;
         }
 
-        $this->allocationRepository->setServer($server)->update(['net0' => $payload]);
+        $rawConfig = collect($this->allocationRepository->setServer($server)->getConfig())->where('key', '=', 'net0')->first()['value'] ?? null;
+
+        if ($rawConfig !== null && strpos($rawConfig, "rate") !== false) {
+            $this->allocationRepository->setServer($server)->update(['net0' => $payload]);
+        }
     }
 
     public function updateAddresses(Server $server, array $addressIds)


### PR DESCRIPTION
This piece of code used to always update the NIC regardless if it actually needed updating. This caused the logs to be unnecessarily spammed on Proxmox hypervisors with configuration changes even though no changes were really being made. 