### PR TITLE
[Feat] Add an install and update script

### DIFF
--- a/install_convoy.sh
+++ b/install_convoy.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# === Styling ===
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print()  { echo -e "${GREEN}==>${NC} $1"; }
+warn()   { echo -e "${YELLOW}WARNING:${NC} $1"; }
+logv()   { [[ "$VERBOSE" == true ]] && echo -e "$1"; }
+run_verbose() {
+    if [[ "$VERBOSE" == true ]]; then
+        "$@"
+    else
+        "$@" > /dev/null
+    fi
+}
+
+# === Banner ===
+echo -e "${GREEN}"
+cat <<'BANNER'
+ ██████  ██████  ███    ██ ██    ██  ██████  ██    ██
+██      ██    ██ ████   ██ ██    ██ ██    ██  ██  ██
+██      ██    ██ ██ ██  ██ ██    ██ ██    ██   ████
+██      ██    ██ ██  ██ ██  ██  ██  ██    ██    ██
+ ██████  ██████  ██   ████   ████    ██████     ██
+BANNER
+echo -e "${NC}"
+
+echo -e "${YELLOW}Convoy Panel Installer${NC} — Production-Ready Setup"
+echo -e "Documentation: ${GREEN}https://convoypanel.com/docs/project/introduction.html${NC}"
+echo -e "Buy License:   ${GREEN}https://console.convoypanel.com/${NC}"
+echo -e "Source Code:   ${GREEN}https://github.com/ConvoyPanel/panel${NC}"
+echo ""
+
+# === Defaults ===
+INSTALL_DIR="/var/www/convoy"
+PANEL_URL="https://github.com/convoypanel/panel/releases/latest/download/panel.tar.gz"
+APP_URL=""
+DB_DATABASE=""
+DB_USERNAME=""
+NON_INTERACTIVE=false
+FORCE=false
+VERBOSE=false
+
+# === Parse Flags ===
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --panel-url)       PANEL_URL="$2"; shift 2 ;;
+        --app-url)         APP_URL="$2"; shift 2 ;;
+        --db-name)         DB_DATABASE="$2"; shift 2 ;;
+        --db-user)         DB_USERNAME="$2"; shift 2 ;;
+        --install-dir)     INSTALL_DIR="$2"; shift 2 ;;
+        --non-interactive) NON_INTERACTIVE=true; shift ;;
+        --force)           FORCE=true; shift ;;
+        --verbose)         VERBOSE=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [options]"
+            echo "Options:"
+            echo "  --panel-url URL       Custom panel tarball URL"
+            echo "  --app-url URL         Application base URL"
+            echo "  --db-name NAME        Database name"
+            echo "  --db-user USER        Database user"
+            echo "  --install-dir PATH    Installation directory"
+            echo "  --non-interactive     Skip prompts"
+            echo "  --force               Force reinstall (stop, wipe, rebuild)"
+            echo "  --verbose             Enable detailed output"
+            exit 0
+            ;;
+        *) warn "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+COMPOSE_CMD="docker compose -f $INSTALL_DIR/docker-compose.yml"
+
+# === Require Root ===
+if [[ "$EUID" -ne 0 ]]; then
+    warn "Please run as root (use sudo)."
+    exit 1
+fi
+
+# === Handle Existing Install in This Directory ===
+if [[ -f "$INSTALL_DIR/.env" ]]; then
+    warn "Convoy already installed at: $INSTALL_DIR"
+
+    if [[ "$FORCE" == false ]]; then
+        if [[ "$NON_INTERACTIVE" == true ]]; then
+            warn "Aborting. Use --force to reinstall."
+            exit 1
+        fi
+
+        read -p "Overwrite this install? This deletes containers and DB. [y/N]: " confirm
+        [[ "$confirm" =~ ^[Yy]$ ]] || { print "Aborted."; exit 0; }
+    fi
+
+    print "Stopping and removing containers..."
+    cd "$INSTALL_DIR"
+    run_verbose $COMPOSE_CMD down -v || true
+
+    print "Wiping $INSTALL_DIR..."
+    if [[ -z "$INSTALL_DIR" || "$INSTALL_DIR" == "/" || "$INSTALL_DIR" == "/root" || "$INSTALL_DIR" == "/home" ]]; then
+        warn "Refusing to wipe suspicious directory: $INSTALL_DIR"
+        exit 1
+    fi
+
+    [[ "$(pwd)" == "$INSTALL_DIR"* ]] && cd /
+    rm -rf "$INSTALL_DIR"
+fi
+
+# === Prompt Configuration ===
+if [[ "$NON_INTERACTIVE" == false ]]; then
+    echo ""
+    read -p "Convoy Panel URL [default: http://localhost]: " input
+    APP_URL="${APP_URL:-${input:-http://localhost}}"
+
+    read -p "Database name [default: convoy]: " input
+    DB_DATABASE="${DB_DATABASE:-${input:-convoy}}"
+
+    read -p "Database user [default: convoy_user]: " input
+    DB_USERNAME="${DB_USERNAME:-${input:-convoy_user}}"
+else
+    APP_URL="${APP_URL:-http://localhost}"
+    DB_DATABASE="${DB_DATABASE:-convoy}"
+    DB_USERNAME="${DB_USERNAME:-convoy_user}"
+fi
+
+# === Generate Secrets ===
+DB_PASSWORD=$(openssl rand -base64 16)
+REDIS_PASSWORD=$(openssl rand -base64 16)
+
+# === Docker Check ===
+print "Checking Docker..."
+if ! command -v docker &> /dev/null; then
+    curl -fsSL https://get.docker.com/ | sh
+else
+    print "Docker is installed."
+fi
+
+# === Setup ===
+print "Setting up directory..."
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+print "Downloading panel..."
+run_verbose curl -Lo panel.tar.gz "$PANEL_URL"
+run_verbose tar -xzf panel.tar.gz
+chmod -R o+w storage/* bootstrap/cache/
+
+# === Configure .env ===
+print "Configuring environment..."
+cp .env.example .env
+sed -i "s|^APP_ENV=.*|APP_ENV=production|" .env
+sed -i "s|^APP_DEBUG=.*|APP_DEBUG=false|" .env
+sed -i "s|^APP_URL=.*|APP_URL=$APP_URL|" .env
+sed -i "s|^DB_DATABASE=.*|DB_DATABASE=$DB_DATABASE|" .env
+sed -i "s|^DB_USERNAME=.*|DB_USERNAME=$DB_USERNAME|" .env
+sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD='$DB_PASSWORD'|" .env
+sed -i "s|^REDIS_PASSWORD=.*|REDIS_PASSWORD='$REDIS_PASSWORD'|" .env
+
+# === Build and Start ===
+print "Building and starting containers..."
+run_verbose $COMPOSE_CMD up -d --build
+
+# === Laravel Setup ===
+print "Installing dependencies..."
+run_verbose $COMPOSE_CMD exec workspace bash -c "composer install --no-dev --optimize-autoloader"
+
+print "Setting app key..."
+run_verbose $COMPOSE_CMD exec workspace bash -c "php artisan key:generate --force && php artisan optimize"
+
+print "Migrating database..."
+run_verbose $COMPOSE_CMD exec workspace php artisan migrate --force
+
+# === Create Admin ===
+if [[ "$NON_INTERACTIVE" == false || "$VERBOSE" == true ]]; then
+    print "Creating admin user..."
+    $COMPOSE_CMD exec workspace php artisan c:user:make --admin=true
+else
+    warn "Skipping admin user creation (interactive only)."
+    echo "You can run this later:"
+    echo "  $COMPOSE_CMD exec workspace php artisan c:user:make --admin=true"
+fi
+
+# === Done ===
+echo ""
+echo -e "${GREEN}=== INSTALL COMPLETE ===${NC}"
+echo "Panel URL:      $APP_URL"
+echo "Install Dir:    $INSTALL_DIR"
+echo "Database Name:  $DB_DATABASE"
+echo "Database User:  $DB_USERNAME"
+echo "Database Pass:  $DB_PASSWORD"
+echo "Redis Password: $REDIS_PASSWORD"
+echo ""
+echo -e "${YELLOW}IMPORTANT: Save these credentials securely!${NC}"
+echo ""
+echo -e "${GREEN}To get started:${NC}"
+echo -e "  - Buy a license at: ${YELLOW}https://console.convoypanel.com/${NC}"
+echo -e "  - View docs at:     ${YELLOW}https://convoypanel.com/docs/project/introduction.html${NC}"
+echo -e "  - License info:     ${YELLOW}https://github.com/ConvoyPanel/panel/blob/develop/LICENSE.md${NC}"

--- a/update-convoy.sh
+++ b/update-convoy.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# === Error Handling ===
+error_exit() {
+    echo -e "${YELLOW}ERROR:${NC} $1"
+    exit 1
+}
+
+# Trap unexpected errors
+trap 'error_exit "An unexpected error occurred." ' ERR
+
+# === Styling ===
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print()  { echo -e "${GREEN}==>${NC} $1"; }
+warn()   { echo -e "${YELLOW}WARNING:${NC} $1"; }
+logv()   { [[ "$VERBOSE" == true ]] && echo -e "$1"; }
+runv()   { [[ "$VERBOSE" == true ]] && "$@" || "$@" > /dev/null; }
+
+# === Banner ===
+echo -e "${GREEN}"
+cat <<'BANNER'
+ ██████  ██████  ███    ██ ██    ██  ██████  ██    ██
+██      ██    ██ ████   ██ ██    ██ ██    ██  ██  ██
+██      ██    ██ ██ ██  ██ ██    ██ ██    ██   ████
+██      ██    ██ ██  ██ ██  ██  ██  ██    ██    ██
+ ██████  ██████  ██   ████   ████    ██████     ██
+
+           Convoy Panel Update Script
+BANNER
+echo -e "${NC}"
+
+# === Defaults ===
+INSTALL_DIR=""
+PANEL_URL="https://github.com/convoypanel/panel/releases/latest/download/panel.tar.gz"
+PANEL_FILE=""
+NON_INTERACTIVE=false
+VERBOSE=false
+BACKUP_DIR="${HOME}/convoy-backups"
+BACKUP_FILE="convoy-backup-$(date +'%Y%m%d-%H%M%S').tar.gz"
+
+# === Parse Flags ===
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+        --panel-url)   PANEL_URL="$2"; shift 2 ;;
+        --panel-file)  PANEL_FILE="$2"; shift 2 ;;
+        --non-interactive) NON_INTERACTIVE=true; shift ;;
+        --verbose)     VERBOSE=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [options]"
+            echo "  --install-dir PATH    Path to Convoy install (if auto-detect fails)"
+            echo "  --panel-url URL       Use custom Convoy panel .tar.gz URL"
+            echo "  --panel-file FILE     Use local Convoy panel .tar.gz file"
+            echo "  --non-interactive     Run without prompts"
+            echo "  --verbose             Enable detailed output"
+            exit 0
+            ;;
+        *) warn "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+# === Auto-detect install dir ===
+if [[ -z "$INSTALL_DIR" ]]; then
+    print "Auto-detecting Convoy install directory..."
+    found_dirs=()
+    for cid in $(docker ps -q); do
+        mounts=$(docker inspect -f '{{range .Mounts}}{{.Source}} {{end}}' "$cid" 2>/dev/null || true)
+        for m in $mounts; do
+            [[ "$m" =~ convoy ]] && [[ -f "$m/docker-compose.yml" ]] && found_dirs+=("$m")
+        done
+    done
+    found_dirs=($(printf "%s\n" "${found_dirs[@]}" | sort -u))
+
+    if [[ ${#found_dirs[@]} -eq 1 ]]; then
+        INSTALL_DIR="${found_dirs[0]}"
+        print "Detected Convoy install: $INSTALL_DIR"
+    elif [[ ${#found_dirs[@]} -gt 1 && "$NON_INTERACTIVE" == false ]]; then
+        echo "Multiple installs found:"
+        select dir in "${found_dirs[@]}"; do
+            INSTALL_DIR="$dir"
+            break
+        done
+    else
+        warn "Could not detect install location."
+        echo "Please rerun with: --install-dir /path/to/convoy"
+        exit 1
+    fi
+fi
+
+cd "$INSTALL_DIR"
+COMPOSE="docker compose -f $INSTALL_DIR/docker-compose.yml"
+
+# === Get current version (from config/app.php) ===
+OLD_VERSION=$(grep "'version' =>" config/app.php | cut -d"'" -f4 || echo "unknown")
+# Prepend 'v' to the current version if not already there
+OLD_VERSION="v$OLD_VERSION"
+print "Current version: $OLD_VERSION"
+
+# === Fetch latest release tag from GitHub ===
+LATEST_VERSION=$(curl -s https://api.github.com/repos/ConvoyPanel/panel/releases/latest | jq -r .tag_name)
+
+# === Compare versions ===
+if [[ "$OLD_VERSION" == "$LATEST_VERSION" ]]; then
+    print "Convoy is already up to date (version: $LATEST_VERSION). No update needed."
+    exit 0
+else
+    print "New release found: $LATEST_VERSION. Proceeding with the update..."
+fi
+
+# === Extract APP_URL from .env ===
+APP_URL=$(grep -oP '^APP_URL=\K.+' .env || error_exit "APP_URL not found in .env")
+
+# === Maintenance Mode ===
+MAINTENANCE_SECRET=$(openssl rand -hex 8)
+print "Entering maintenance mode..."
+runv $COMPOSE up -d workspace || error_exit "Failed to start Convoy containers in maintenance mode"
+runv $COMPOSE exec workspace php artisan down --secret="$MAINTENANCE_SECRET" || error_exit "Failed to set Convoy into maintenance mode"
+
+echo -e "${YELLOW}Bypass URL during maintenance:${NC}"
+echo "  $APP_URL/$MAINTENANCE_SECRET"
+
+# === Horizon Job Check ===
+print "Please check the Horizon job queue manually before proceeding."
+echo -e "${YELLOW}Navigate to the following URL to check job statuses:${NC}"
+echo "  $APP_URL/horizon"
+if [[ "$NON_INTERACTIVE" == false ]]; then
+    read -p "Have you verified that all jobs are completed? [y/N]: " ready
+    [[ "$ready" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+fi
+
+# === Stop containers ===
+print "Stopping containers..."
+runv $COMPOSE down || error_exit "Failed to stop Convoy containers"
+
+# === Backup Creation ===
+print "Backing up Convoy installation to: $BACKUP_DIR/$BACKUP_FILE"
+mkdir -p "$BACKUP_DIR"
+runv tar -czf "$BACKUP_DIR/$BACKUP_FILE" . || error_exit "Failed to create backup"
+
+# === Download and unpack ===
+if [[ -n "$PANEL_FILE" ]]; then
+    print "Using local panel archive: $PANEL_FILE"
+    runv tar -xzf "$PANEL_FILE" || error_exit "Failed to unpack the local panel archive"
+else
+    print "Downloading panel from: $PANEL_URL"
+    runv curl -L "$PANEL_URL" -o panel.tar.gz || error_exit "Failed to download panel"
+    runv tar -xzf panel.tar.gz || error_exit "Failed to unpack downloaded panel"
+fi
+
+print "Fixing permissions..."
+chmod -R o+w storage/* bootstrap/cache/ || error_exit "Failed to set correct file permissions"
+
+# === Rebuild containers ===
+print "Rebuilding containers..."
+runv $COMPOSE up -d --build || error_exit "Failed to rebuild Convoy containers"
+
+# === Dependencies & DB ===
+print "Installing Composer dependencies..."
+runv $COMPOSE exec workspace composer install --no-dev --optimize-autoloader || error_exit "Failed to install Composer dependencies"
+
+print "Running database migrations..."
+runv $COMPOSE exec workspace php artisan migrate --force || error_exit "Failed to run database migrations"
+
+print "Refreshing application cache..."
+runv $COMPOSE exec workspace php artisan optimize || error_exit "Failed to optimize application"
+
+# === Restart & exit maintenance ===
+print "Restarting stack..."
+runv $COMPOSE restart || error_exit "Failed to restart Convoy containers"
+
+print "Exiting maintenance mode..."
+runv $COMPOSE exec workspace php artisan up || error_exit "Failed to exit maintenance mode"
+
+# === Get new version ===
+NEW_VERSION=$(grep "'version' =>" config/app.php | cut -d"'" -f4 || echo "unknown")
+
+# === Done ===
+echo ""
+echo -e "${GREEN}=== UPDATE COMPLETE ===${NC}"
+echo "Updated: $OLD_VERSION  =>  $NEW_VERSION"
+echo "Backup stored at: $BACKUP_DIR/$BACKUP_FILE"


### PR DESCRIPTION
This pull request introduces two new scripts to manage the installation and updating of the Convoy Panel. The `install_convoy.sh` script provides a comprehensive setup for installing the Convoy Panel, while the `update-convoy.sh` script facilitates updating an existing installation. The most important changes include the addition of error handling, user prompts, and Docker container management.

### New Installation Script:
* [`install_convoy.sh`](diffhunk://#diff-f8b90271c03cd42a399bba4ba8bfcbb46aa1e30641c586c1e6627549f8d2b19cR1-R201): Added a new script to automate the installation of the Convoy Panel, including setting up Docker, configuring environment variables, and creating an admin user.

### New Update Script:
* [`update-convoy.sh`](diffhunk://#diff-0abd57d2f64d4220e9bcdfc270078c4745d375f16958030b0b3158b02ca7e679R1-R186): Introduced a script to update the Convoy Panel, including error handling, backup creation, and Docker container management.

The reason why I made this, is because of some things I read on the support discord….. 